### PR TITLE
fix: ensure the last_fan_speed and real fan status are equal on restart

### DIFF
--- a/vim3-fan-controller/script.sh
+++ b/vim3-fan-controller/script.sh
@@ -15,6 +15,7 @@ setpoint_high=$(bashio::config 'threshold_3')
 interval=$(bashio::config 'interval')
 tolerance=$(bashio::config 'tolerance')
 last_fan_speed=0
+$fan_control_command 0
 
 # Log the configuration
 bashio::log.info "===================== Configuration ====================="


### PR DESCRIPTION
Fix script behhavior on restart with a running fan: ensure the `last_fan_speed` (0 at init) is identical to the real fan state by setting to 0.

It prevents tthe situation where the fan is enabled at speed 1, the container is restarted and the temp is below low threshold + tolerance: then the script won't reset the speed to 0.